### PR TITLE
Misc doc changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,29 @@
-/_build
-/cover
-/deps
-/doc
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
-mix.lock
+
+# Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+# Ignore package tarball (built via "mix hex.build").
+eternal-*.tar
+
+# Temporary files for e.g. tests.
+/tmp
+
+# Misc.
+mix.lock

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Eternal
-[![Build Status](https://img.shields.io/github/workflow/status/whitfin/eternal/CI)](https://github.com/whitfin/eternal/actions) [![Coverage Status](https://img.shields.io/coveralls/whitfin/eternal.svg)](https://coveralls.io/github/whitfin/eternal) [![Hex.pm Version](https://img.shields.io/hexpm/v/eternal.svg)](https://hex.pm/packages/eternal) [![Documentation](https://img.shields.io/badge/docs-latest-yellowgreen.svg)](https://hexdocs.pm/eternal/)
+
+[![Build Status](https://img.shields.io/github/workflow/status/whitfin/eternal/CI)](https://github.com/whitfin/eternal/actions)
+[![Coverage Status](https://img.shields.io/coveralls/whitfin/eternal.svg)](https://coveralls.io/github/whitfin/eternal)
+[![Module Version](https://img.shields.io/hexpm/v/eternal.svg)](https://hex.pm/packages/eternal)
+[![Documentation](https://img.shields.io/badge/docs-latest-yellowgreen.svg)](https://hexdocs.pm/eternal/)
+[![Total Download](https://img.shields.io/hexpm/dt/eternal.svg)](https://hex.pm/packages/eternal)
+[![License](https://img.shields.io/hexpm/l/eternal.svg)](https://github.com/whitfin/eternal/blob/master/LICENSE)
+[![Last Updated](https://img.shields.io/github/last-commit/whitfin/eternal.svg)](https://github.com/whitfin/eternal/commits/master)
 
 Eternal is a simple way to monitor an ETS table to ensure that it never dies. It works by using bouncing GenServers to ensure that both an owner and heir are always available, via the use of scheduled monitoring and message passing. The idea is similar to that of the Immortal library, but taking it further to ensure a more bulletproof solution - and removing the need to have a single process dedicated to owning your ETS table.
 
@@ -7,19 +14,23 @@ Eternal is a simple way to monitor an ETS table to ensure that it never dies. It
 
 Eternal is available on [Hex](https://hex.pm/). You can install the package via:
 
-1. Add eternal to your list of dependencies in `mix.exs`:
+1. Add `:eternal` to your list of dependencies in `mix.exs`:
 
     ```elixir
     def deps do
-      [{:eternal, "~> 1.2"}]
+      [
+        {:eternal, "~> 1.2"}
+      ]
     end
     ```
 
-2. Ensure eternal is started before your application:
+2. Ensure `:eternal` is started before your application for Elixir version earlier than 1.4:
 
     ```elixir
     def application do
-      [applications: [:eternal]]
+      [
+        applications: [:eternal]
+      ]
     end
     ```
 
@@ -105,7 +116,7 @@ end
 
 ## Contributions
 
-If you feel something can be improved, or have any questions about certain behaviours or pieces of implementation, please feel free to file an issue. Proposed changes should be taken to issues before any PRs to avoid wasting time on code which might not be merged upstream.
+If you feel something can be improved, or have any questions about certain behaviours or pieces of implementation, please feel free to file an issue. Proposed changes should be taken to issues before any Pull Requests (PRs) to avoid wasting time on code which might not be merged upstream.
 
 ## Credits
 
@@ -113,3 +124,10 @@ Thanks to the following for the inspiration for this project:
 
 - [Daniel Berkompas](https://github.com/danielberkompas/immortal)
 - [Steve Vinoski](http://steve.vinoski.net/blog/2011/03/23/dont-lose-your-ets-tables/)
+
+## Copyright and License
+
+Copyright (c) 2016 Isaac Whitfield
+
+This library is MIT licensed. See the
+[LICENSE](https://github.com/whitfin/eternal/blob/master/LICENSE) for details.

--- a/lib/eternal/priv.ex
+++ b/lib/eternal/priv.ex
@@ -1,8 +1,9 @@
 defmodule Eternal.Priv do
-  @moduledoc false
-  # This module contains code private to the Eternal project, basically just
-  # providing utility functions and macros. Nothing too interesting to see here
-  # beyond shorthands for common blocks.
+  @moduledoc """
+  This module contains code private to the Eternal project, basically just
+  providing utility functions and macros. Nothing too interesting to see here
+  beyond shorthands for common blocks.
+  """
 
   # we need is_table/1
   import Eternal.Table

--- a/lib/eternal/server.ex
+++ b/lib/eternal/server.ex
@@ -1,12 +1,13 @@
 defmodule Eternal.Server do
-  @moduledoc false
-  # This module remains internal to Eternal and should not be manually created
-  # by anyone external so it shall remain undocumented for now.
-  #
-  # Basically, this module implements an extremely base GenServer which listens
-  # on two messages - the first is that of ETS to trigger a log that the table
-  # owner has changed, and the other is a recognisation that a new heir has been
-  # attached and needs assigning to ETS (as only an owner can set the heir).
+  @moduledoc """
+  This module remains internal to Eternal and should not be manually created
+  by anyone external so it shall remain undocumented for now.
+
+  Basically, this module implements an extremely base GenServer which listens
+  on two messages - the first is that of ETS to trigger a log that the table
+  owner has changed, and the other is a recognition that a new heir has been
+  attached and needs assigning to ETS (as only an owner can set the heir).
+  """
 
   # use default server behaviour
   use GenServer

--- a/lib/eternal/supervisor.ex
+++ b/lib/eternal/supervisor.ex
@@ -1,9 +1,10 @@
 defmodule Eternal.Supervisor do
-  @moduledoc false
-  # This module contains the main Eternal Supervisor which is used to manage the
-  # two internal GenServers which act as owner/heir to the ETS table. There's little
-  # in here beyond setting up a Supervision tree, as we want to keep the code simple
-  # to make it pretty bulletproof as an implementation.
+  @moduledoc """
+  This module contains the main Eternal Supervisor which is used to manage the
+  two internal GenServers which act as owner/heir to the ETS table. There's little
+  in here beyond setting up a Supervision tree, as we want to keep the code simple
+  to make it pretty bulletproof as an implementation.
+  """
 
   # this is a supervisor
   use Supervisor

--- a/lib/eternal/table.ex
+++ b/lib/eternal/table.ex
@@ -1,8 +1,9 @@
 defmodule Eternal.Table do
-  @moduledoc false
-  # This module contains functions related to interactions with tables. At the moment
-  # this just consists of guard expressions to determine valid tables, and the ability
-  # to convert a table identifier to a valid Supervisor name.
+  @moduledoc """
+  This module contains functions related to interactions with tables. At the moment
+  this just consists of guard expressions to determine valid tables, and the ability
+  to convert a table identifier to a valid Supervisor name.
+  """
 
   # define a table typespec
   @opaque t :: number | atom

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,6 @@
 defmodule Eternal.Mixfile do
   use Mix.Project
 
-  @url_docs "http://hexdocs.pm/eternal"
   @url_github "https://github.com/whitfin/eternal"
 
   def project do
@@ -9,28 +8,11 @@ defmodule Eternal.Mixfile do
       app: :eternal,
       name: "Eternal",
       description: "Make your ETS tables live forever",
-      package: %{
-        files: [
-          "lib",
-          "mix.exs",
-          "LICENSE",
-          "README.md"
-        ],
-        licenses: [ "MIT" ],
-        links: %{
-          "Docs" => @url_docs,
-          "GitHub" => @url_github
-        },
-        maintainers: [ "Isaac Whitfield" ]
-      },
       version: "1.2.2",
       elixir: "~> 1.2",
       deps: deps(),
-      docs: [
-        extras: [ "README.md" ],
-        source_ref: "master",
-        source_url: @url_github
-      ],
+      docs: docs(),
+      package: package(),
       test_coverage: [
         tool: ExCoveralls
       ],
@@ -43,26 +25,33 @@ defmodule Eternal.Mixfile do
     ]
   end
 
-  # Configuration for the OTP application
-  #
-  # Type "mix help compile.app" for more information
   def application do
     [applications: [:logger]]
   end
 
-  # Dependencies can be Hex packages:
-  #
-  #   {:mydep, "~> 0.3.0"}
-  #
-  # Or git/path repositories:
-  #
-  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
-  #
-  # Type "mix help deps" for more examples and options
   defp deps do
     [
-      { :ex_doc, "~> 0.16", optional: true, only: [ :docs ] },
-      { :excoveralls, "~> 0.5", optional: true, only: [ :cover ] }
+      {:ex_doc, "~> 0.16", optional: true, only: [:docs]},
+      {:excoveralls, "~> 0.5", optional: true, only: [:cover]}
+    ]
+  end
+
+  defp package do
+    [
+      files: ["lib", "mix.exs", "LICENSE", "README.md"],
+      licenses: ["MIT"],
+      links: %{"GitHub" => @url_github},
+      maintainers: ["Isaac Whitfield"]
+    ]
+  end
+
+  defp docs do
+    [
+      extras: ["README.md": [title: "Overview"]],
+      main: "readme",
+      source_ref: "master",
+      source_url: @url_github,
+      api_reference: false
     ]
   end
 end


### PR DESCRIPTION
Besides other changes, this commit ensures the generated HTML doc for
HexDocs.pm will become the main source doc for this Elixir library.

List of changes:
* Update gitignore
* Add mix format config
* Add expanded acronym
* Update installation instruction
* Add license section
* Badges and more badges!
* Set readme as main html page
* Refactor project config
* Remove api reference page
* Rename title page
* Open up all private module docs